### PR TITLE
修复回归决策树CART实现的bug：

### DIFF
--- a/charpter7_decision_tree/CART.ipynb
+++ b/charpter7_decision_tree/CART.ipynb
@@ -50,7 +50,7 @@
     "### 定义二叉决策树\n",
     "class BinaryDecisionTree(object):\n",
     "    ### 决策树初始参数\n",
-    "    def __init__(self, min_samples_split=2, min_gini_impurity=999,\n",
+    "    def __init__(self, min_samples_split=2, min_gini_impurity=float(\"inf\"),\n",
     "                 max_depth=float(\"inf\"), loss=None):\n",
     "        # 根结点\n",
     "        self.root = None  \n",
@@ -76,7 +76,7 @@
     "    ### 决策树构建函数\n",
     "    def _build_tree(self, X, y, current_depth=0):\n",
     "        # 初始化最小基尼不纯度\n",
-    "        init_gini_impurity = 999\n",
+    "        init_gini_impurity = self.gini_impurity_calculation(y)\n",
     "        # 初始化最佳特征索引和阈值\n",
     "        best_criteria = None    \n",
     "        # 初始化数据子集\n",
@@ -87,6 +87,7 @@
     "        # 获取样本数和特征数\n",
     "        n_samples, n_features = X.shape\n",
     "        # 设定决策树构建条件\n",
+    "        best_criteria = None\n",
     "        # 训练样本数量大于节点最小分裂样本数且当前树深度小于最大深度\n",
     "        if n_samples >= self.min_samples_split and current_depth <= self.max_depth:\n",
     "            # 遍历计算每个特征的基尼不纯度\n",
@@ -121,8 +122,8 @@
     "                                \"righty\": Xy2[:, n_features:]   \n",
     "                                }\n",
     "        \n",
-    "        # 如果计算的最小不纯度小于设定的最小不纯度\n",
-    "        if init_gini_impurity < self.mini_gini_impurity:\n",
+    "        # 如果best_criteria不为None，且计算的最小不纯度小于设定的最小不纯度\n",
+    "        if best_criteria and init_gini_impurity < self.mini_gini_impurity:\n",
     "            # 分别构建左右子树\n",
     "            left_branch = self._build_tree(best_sets[\"leftX\"], best_sets[\"lefty\"], current_depth + 1)\n",
     "            right_branch = self._build_tree(best_sets[\"rightX\"], best_sets[\"righty\"], current_depth + 1)\n",
@@ -149,7 +150,7 @@
     "        # 判断落入左子树还是右子树\n",
     "        branch = tree.right_branch\n",
     "        if isinstance(feature_value, int) or isinstance(feature_value, float):\n",
-    "            if feature_value >= tree.threshold:\n",
+    "            if feature_value <= tree.threshold:\n",
     "                branch = tree.left_branch\n",
     "        elif feature_value == tree.threshold:\n",
     "            branch = tree.left_branch\n",
@@ -171,16 +172,15 @@
    "source": [
     "### CART回归树\n",
     "class RegressionTree(BinaryDecisionTree):\n",
-    "    def _calculate_variance_reduction(self, y, y1, y2):\n",
-    "        var_tot = np.var(y, axis=0)\n",
+    "    def _calculate_weighted_mse(self, y, y1, y2):\n",
     "        var_y1 = np.var(y1, axis=0)\n",
     "        var_y2 = np.var(y2, axis=0)\n",
     "        frac_1 = len(y1) / len(y)\n",
     "        frac_2 = len(y2) / len(y)\n",
-    "        # 计算方差减少量\n",
-    "        variance_reduction = var_tot - (frac_1 * var_y1 + frac_2 * var_y2)\n",
+    "        # 计算左右子树加权总均方误差\n",
+    "        weighted_mse = frac_1 * var_y1 + frac_2 * var_y2\n",
     "        \n",
-    "        return sum(variance_reduction)\n",
+    "        return sum(weighted_mse)\n",
     "\n",
     "    # 节点值取平均\n",
     "    def _mean_of_y(self, y):\n",
@@ -188,8 +188,9 @@
     "        return value if len(value) > 1 else value[0]\n",
     "\n",
     "    def fit(self, X, y):\n",
-    "        self.impurity_calculation = self._calculate_variance_reduction\n",
+    "        self.impurity_calculation = self._calculate_weighted_mse\n",
     "        self._leaf_value_calculation = self._mean_of_y\n",
+    "        self.gini_impurity_calculation = lambda y: np.var(y, axis=0)\n",
     "        super(RegressionTree, self).fit(X, y)"
    ]
   },
@@ -224,6 +225,7 @@
     "    def fit(self, X, y):\n",
     "        self.impurity_calculation = self._calculate_gini_impurity\n",
     "        self._leaf_value_calculation = self._majority_vote\n",
+    "        self.gini_impurity_calculation = calculate_gini\n",
     "        super(ClassificationTree, self).fit(X, y)"
    ]
   },
@@ -263,7 +265,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.0\n"
+      "0.9777777777777777\n"
      ]
     }
    ],
@@ -285,13 +287,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean Squared Error: 134.4803289473684\n"
+      "Mean Squared Error: 23.03842105263158\n"
      ]
     }
    ],
    "source": [
-    "from sklearn.datasets import load_boston\n",
-    "X, y = load_boston(return_X_y=True)\n",
+    "import pandas as pd\n",
+    "\n",
+    "# 波士顿房价数据集的原始 URL\n",
+    "data_url = \"http://lib.stat.cmu.edu/datasets/boston\"\n",
+    "\n",
+    "# 从 URL 加载数据\n",
+    "raw_df = pd.read_csv(data_url, sep=\"\\s+\", skiprows=22, header=None)\n",
+    "\n",
+    "# 处理数据\n",
+    "data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])  # 拼接特征数据\n",
+    "target = raw_df.values[1::2, 2]  # 目标变量\n",
+    "\n",
+    "# 将数据和目标变量转换为 NumPy 数组\n",
+    "X = np.array(data)\n",
+    "y = np.array(target)\n",
+    "\n",
     "y = y.reshape(-1,1)\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)\n",
     "model = RegressionTree()\n",
@@ -311,7 +327,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean Squared Error: 28.75368421052632\n"
+      "Mean Squared Error: 23.600592105263157\n"
      ]
     }
    ],
@@ -349,7 +365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.19"
   },
   "toc": {
    "base_numbering": 1,

--- a/charpter7_decision_tree/utils.py
+++ b/charpter7_decision_tree/utils.py
@@ -4,14 +4,14 @@ import numpy as np
 def feature_split(X, feature_i, threshold):
     split_func = None
     if isinstance(threshold, int) or isinstance(threshold, float):
-        split_func = lambda sample: sample[feature_i] >= threshold
+        split_func = lambda sample: sample[feature_i] <= threshold
     else:
         split_func = lambda sample: sample[feature_i] == threshold
 
     X_left = np.array([sample for sample in X if split_func(sample)])
     X_right = np.array([sample for sample in X if not split_func(sample)])
 
-    return np.array([X_left, X_right])
+    return X_left, X_right
 
 
 ### 计算基尼指数


### PR DESCRIPTION
## 1. 书中提到，基于numpy实现的回归树的MSE比sklearn的差很多，实际测试也确实差了4、5倍左右。 修改之后，差距会很小，大多数时候差距在10%以内。
旧代码的问题是：在回归树RegressionTree类中，把**方差减小量**作为损失函数值，决策树的分裂点应该满足**方差减小量**取最大值，但父类BinaryDecisionTree的逻辑是寻找损失函数最小的点作为分裂点。
### 修改的思路有两个：
思路1： 在RegressionTree类中，对”方差减小量“取反
思路2： 在RegressionTree类中，不计算”方差减小量“，只计算分裂后“左右子树的加权方差”
我选择第2个思路。原因是：
### （1）与分类树的逻辑保持一致，分类树并没有计算“基尼指数的变化量”，只计算分裂后“左右子树的加权基尼指数”
### （2）在父类BinaryDecisionTree的代码中，已经记录了分裂前的初始方差（变量名init_gini_impurity），在寻找分裂点时，分裂后的方差必须要小于init_gini_impurity，并且会持续把init_gini_impurity更新到最小值，直到找到方差最小的分裂点为止，找到“方差最小的分裂点”就等价于“方差减小量”取到最大值，所以在RegressionTree类中计算”方差减小量“是重复多余的。
## 2. scikit-learn从1.2版本开始移除了load_boston函数，这个函数原本用于加载波士顿房价数据集。移除的原因是该数据集存在伦理问题。scikit-learn提示可以使用pandas加载原数据。
## 3. 左子树和右子树弄反了，左子树应该是<= threshold，原代码则是>= threshold。当然这并不会导致严重问题，仅仅是与书中的公式和习惯不符。
## 4. 在utils.py文件中，feature_split函数的返回值类型有误，原代码运行会报错。