### PR TITLE
解决第11章GBDT误差太大的问题

### DIFF
--- a/charpter11_GBDT/gbdt.ipynb
+++ b/charpter11_GBDT/gbdt.ipynb
@@ -57,22 +57,21 @@
     "                                             max_depth=self.max_depth))\n",
     "    # 拟合方法\n",
     "    def fit(self, X, y):\n",
-    "        # 前向分步模型初始化，第一棵树\n",
-    "        self.estimators[0].fit(X, y)\n",
-    "        # 第一棵树的预测结果\n",
-    "        y_pred = self.estimators[0].predict(X)\n",
+    "        # 初始化预测结果（不同的初始值会影响收敛速度，通常使用均值）\n",
+    "        self.initial_prediction = np.mean(y)\n",
+    "        y_pred = np.full_like(y, self.initial_prediction)\n",
     "        # 前向分步迭代训练\n",
-    "        for i in range(1, self.n_estimators):\n",
+    "        for i in range(self.n_estimators):\n",
     "            gradient = self.loss.gradient(y, y_pred)\n",
     "            self.estimators[i].fit(X, gradient)\n",
-    "            y_pred -= np.multiply(self.learning_rate, self.estimators[i].predict(X))\n",
+    "            y_pred -= self.learning_rate * np.array(self.estimators[i].predict(X)).reshape(-1, 1)\n",
     "            \n",
     "    # 预测方法\n",
     "    def predict(self, X):\n",
     "        # 回归树预测\n",
-    "        y_pred = self.estimators[0].predict(X)\n",
-    "        for i in range(1, self.n_estimators):\n",
-    "            y_pred -= np.multiply(self.learning_rate, self.estimators[i].predict(X))\n",
+    "        y_pred = np.zeros(X.shape[0]).reshape(-1, 1) + self.initial_prediction\n",
+    "        for i in range(self.n_estimators):\n",
+    "            y_pred -= self.learning_rate *  np.array(self.estimators[i].predict(X)).reshape(-1, 1)\n",
     "        # 分类树预测\n",
     "        if not self.regression:\n",
     "            # 将预测值转化为概率\n",
@@ -106,8 +105,8 @@
     "        \n",
     "### GBDT回归树\n",
     "class GBDTRegressor(GBDT):\n",
-    "      def __init__(self, n_estimators=300, learning_rate=0.1, min_samples_split=2,\n",
-    "                 min_var_reduction=1e-6, max_depth=3):\n",
+    "      def __init__(self, n_estimators=15, learning_rate=0.5, min_samples_split=2,\n",
+    "                 min_var_reduction=float(\"inf\"), max_depth=3):\n",
     "        super(GBDTRegressor, self).__init__(n_estimators=n_estimators,\n",
     "                                            learning_rate=learning_rate,\n",
     "                                            min_samples_split=min_samples_split,\n",
@@ -118,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,31 +133,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean Squared Error of NumPy GBRT: 84.29078032628252\n"
+      "Mean Squared Error of NumPy GBRT: 13.782569688896887\n"
      ]
     }
    ],
    "source": [
-    "### GBDT分类树\n",
-    "# 导入sklearn数据集模块\n",
-    "from sklearn import datasets\n",
-    "# 导入波士顿房价数据集\n",
-    "boston = datasets.load_boston()\n",
-    "# 打乱数据集\n",
-    "X, y = data_shuffle(boston.data, boston.target, seed=13)\n",
-    "X = X.astype(np.float32)\n",
-    "offset = int(X.shape[0] * 0.9)\n",
-    "# 划分数据集\n",
+    "import pandas as pd\n",
+    "\n",
+    "# 波士顿房价数据集的原始 URL\n",
+    "data_url = \"http://lib.stat.cmu.edu/datasets/boston\"\n",
+    "\n",
+    "# 从 URL 加载数据\n",
+    "raw_df = pd.read_csv(data_url, sep=\"\\s+\", skiprows=22, header=None)\n",
+    "\n",
+    "# 处理数据\n",
+    "data = np.hstack([raw_df.values[::2, :], raw_df.values[1::2, :2]])  # 拼接特征数据\n",
+    "target = raw_df.values[1::2, 2]  # 目标变量\n",
+    "\n",
+    "# 将数据和目标变量转换为 NumPy 数组\n",
+    "X = np.array(data)\n",
+    "y = np.array(target)\n",
+    "y = y.reshape(-1,1)\n",
     "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3)\n",
     "# 创建GBRT实例\n",
-    "model = GBDTRegressor()\n",
+    "model = GBDTRegressor(n_estimators=15, learning_rate=0.5, min_samples_split=4,\n",
+    "                 min_var_reduction=float(\"inf\"), max_depth=3)\n",
     "# 模型训练\n",
     "model.fit(X_train, y_train)\n",
     "# 模型预测\n",
@@ -170,14 +176,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Mean Squared Error of sklearn GBRT: 14.885053466425939\n"
+      "Mean Squared Error of sklearn GBRT: 14.54623458175684\n"
      ]
     }
    ],
@@ -185,10 +191,10 @@
     "# 导入sklearn GBDT模块\n",
     "from sklearn.ensemble import GradientBoostingRegressor\n",
     "# 创建模型实例\n",
-    "reg = GradientBoostingRegressor(n_estimators=200, learning_rate=0.5,\n",
-    "                                 max_depth=4, random_state=0)\n",
+    "reg = GradientBoostingRegressor(n_estimators=15, learning_rate=0.5,\n",
+    "                                 max_depth=3, random_state=0)\n",
     "# 模型拟合\n",
-    "reg.fit(X_train, y_train)\n",
+    "reg.fit(X_train, y_train.ravel())\n",
     "# 模型预测\n",
     "y_pred = reg.predict(X_test)\n",
     "# 计算模型预测的均方误差\n",
@@ -220,7 +226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.14"
   },
   "toc": {
    "base_numbering": 1,

--- a/charpter11_GBDT/utils.py
+++ b/charpter11_GBDT/utils.py
@@ -4,14 +4,14 @@ import numpy as np
 def feature_split(X, feature_i, threshold):
     split_func = None
     if isinstance(threshold, int) or isinstance(threshold, float):
-        split_func = lambda sample: sample[feature_i] >= threshold
+        split_func = lambda sample: sample[feature_i] <= threshold
     else:
         split_func = lambda sample: sample[feature_i] == threshold
 
     X_left = np.array([sample for sample in X if split_func(sample)])
     X_right = np.array([sample for sample in X if not split_func(sample)])
 
-    return np.array([X_left, X_right])
+    return X_left, X_right
 
 
 ### 计算基尼指数

--- a/charpter7_decision_tree/CART.ipynb
+++ b/charpter7_decision_tree/CART.ipynb
@@ -87,7 +87,6 @@
     "        # 获取样本数和特征数\n",
     "        n_samples, n_features = X.shape\n",
     "        # 设定决策树构建条件\n",
-    "        best_criteria = None\n",
     "        # 训练样本数量大于节点最小分裂样本数且当前树深度小于最大深度\n",
     "        if n_samples >= self.min_samples_split and current_depth <= self.max_depth:\n",
     "            # 遍历计算每个特征的基尼不纯度\n",


### PR DESCRIPTION
1. 修复决策树的bug：在上一次commit已经修复，只需要把第七章的代码完全复制过来；具体看上一次的提交信息：f7b9b7efd3b6ca9ace7a58df1eeb8d7338d7d5a9
2. 修复决策树几乎不会训练的bug：GBDTRegressor类的初始化参数min_var_reduction=1e-6，由于这个值太小，会导致决策树几乎不会生成分支，所以我这里把默认值改为无穷大float("inf")。改动到这一步，误差已经大幅减小；
决策树基类fit函数有如下if判断，当min_var_reduction=1e-6时，self.min_gini_impurity=1e-6，所以几乎不会满足进入if的条件：
```python
# 如果计算的最小不纯度小于设定的最小不纯度
if init_gini_impurity < self.min_gini_impurity:
    # 分别构建左右子树
    left_branch = self._build_tree(best_sets["leftX"], best_sets["lefty"], current_depth + 1)
    right_branch = self._build_tree(best_sets["rightX"], best_sets["righty"], current_depth + 1)
    return TreeNode(feature_i=best_criteria["feature_i"], threshold=best_criteria["threshold"], left_branch=left_branch, right_branch=right_branch)
```
3. 修复GBDT训练收敛太慢的bug（几乎不收敛）：把预测值y_pred初始化为均值，可以明显加快收敛，学习率不变的情况下，训练15次就差不多够了，误差还能稍微再降低。
4. 删除第7章决策树冗余，这是上一次commit增加的一行冗余代码。